### PR TITLE
feat: support connecting to Firebolt Core with no credentials (FB-2858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The SDK uses the following parameters to connect to Firebolt:
 - `account_name`: The name of your Firebolt [account](https://docs.firebolt.io/guides/managing-your-organization/managing-accounts).
 - `database`: (Optional) The name of the [database](https://docs.firebolt.io/overview/security/rbac/database-permissions) to connect to.
 - `engine`: (Optional) The name of the [engine](https://docs.firebolt.io/overview/security/rbac/engine-permissions) to run SQL queries on.
+- `url`: (Firebolt Core only) The URL of a [Firebolt Core](https://docs.firebolt.io/firebolt-core/) server, for example `http://localhost:3473`. Selects the no-authentication Core connection; `client_id`, `client_secret`, `account_name` and `engine` are not accepted alongside it.
 
 To establish a connection to a Firebolt database, use the builder pattern with your credentials and database details. The following example shows how to connect to Firebolt:
 
@@ -56,6 +57,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+## Connect to Firebolt Core
+
+[Firebolt Core](https://docs.firebolt.io/firebolt-core/) has no authentication. Pass its URL with `with_url` and omit credentials:
+
+```rust
+use firebolt::FireboltClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = FireboltClient::builder()
+        .with_url("http://localhost:3473".to_string())
+        .with_database("your_database_name".to_string())
+        .build()
+        .await?;
+
+    let result = client.query("SELECT 1").await?;
+
+    println!("Rows: {}", result.rows.len());
+    Ok(())
+}
+```
+
+The URL must include an `http://` or `https://` scheme and a host; the port is optional, and a path is allowed for a Core server behind a reverse proxy. A `user:password@` authority or a query string is rejected. `with_database` is optional and issues `USE DATABASE` on connect.
+
+Core has no service accounts, accounts or engines, so `with_credentials`, `with_account` and `with_engine` are rejected with a `FireboltError::Configuration` rather than ignored. For a Core client, `client_id()`, `client_secret()` and `api_endpoint()` return `None`.
 
 ## Run Queries
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Firebolt Rust SDK enables Rust developers to connect to Firebolt databases s
 
 ## Prerequisites
 
-You must have the following prerequisites before you can connect your Firebolt account to Rust:
+You must have the following prerequisites before you can connect your Firebolt account to Rust. Only Rust itself is required to connect to [Firebolt Core](https://docs.firebolt.io/firebolt-core/), which has no accounts and no authentication — see [Connect to Firebolt Core](#connect-to-firebolt-core).
 
 * **Rust installed and configured** on your system. The minimum supported version is 1.70 or higher. If you do not have Rust installed, you can download it from [rustup.rs](https://rustup.rs/).
 * **Firebolt account** – You need an active Firebolt account. If you do not have one, you can [sign up](https://go.firebolt.io/signup) for one.
@@ -35,7 +35,7 @@ The SDK uses the following parameters to connect to Firebolt:
 - `account_name`: The name of your Firebolt [account](https://docs.firebolt.io/guides/managing-your-organization/managing-accounts).
 - `database`: (Optional) The name of the [database](https://docs.firebolt.io/overview/security/rbac/database-permissions) to connect to.
 - `engine`: (Optional) The name of the [engine](https://docs.firebolt.io/overview/security/rbac/engine-permissions) to run SQL queries on.
-- `url`: (Firebolt Core only) The URL of a [Firebolt Core](https://docs.firebolt.io/firebolt-core/) server, for example `http://localhost:3473`. Selects the no-authentication Core connection; `client_id`, `client_secret`, `account_name` and `engine` are not accepted alongside it.
+- `url`: (Firebolt Core only) The address of a [Firebolt Core](https://docs.firebolt.io/firebolt-core/) server as `<scheme>://<host>[:<port>]`, for example `http://localhost:3473`. Selects the no-authentication Core connection; `client_id`, `client_secret`, `account_name` and `engine` are not accepted alongside it.
 
 To establish a connection to a Firebolt database, use the builder pattern with your credentials and database details. The following example shows how to connect to Firebolt:
 
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The URL must include an `http://` or `https://` scheme and a host; the port is optional, and a path is allowed for a Core server behind a reverse proxy. A `user:password@` authority or a query string is rejected. `with_database` is optional and issues `USE DATABASE` on connect.
+The URL must be `<scheme>://<host>[:<port>]` with an `http` or `https` scheme; the port is optional. A path, a `user:password@` authority, and a query string or fragment are each rejected. `with_database` is optional and issues `USE DATABASE` on connect.
 
 Core has no service accounts, accounts or engines, so `with_credentials`, `with_account` and `with_engine` are rejected with a `FireboltError::Configuration` rather than ignored. For a Core client, `client_id()`, `client_secret()` and `api_endpoint()` return `None`.
 
@@ -253,8 +253,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 | Error | Likely Cause                  | Solution                                                                       |
 |-------|-------------------------------|--------------------------------------------------------------------------------|
-| `Authentication error: Invalid credentials` | Incorrect client ID or secret | Verify your service account credentials in the Firebolt console                |
-| `Configuration error: CLIENT_ID is required` | Missing required parameter    | Ensure all required parameters are provided to the builder                     |
+| `Authentication error: Invalid credentials` (Cloud) | Incorrect client ID or secret | Verify your service account credentials in the Firebolt console                |
+| `Authentication error: ...` (Core) | The Core server rejected the request | Core does not authenticate. The message is the server's own response body — check what sits in front of your Core server |
+| `Configuration error: client_id is required` | Missing required parameter    | Ensure all required parameters are provided to the builder                     |
+| `Configuration error: ... cannot be combined with url` | Cloud parameters passed with a Core `url` | Drop `with_credentials`, `with_account` and `with_engine`; Core has none of them |
+| `Configuration error: Invalid url: ...` | Malformed Core `url`          | Use `<scheme>://<host>[:<port>]` with an `http` or `https` scheme, and no path, credentials or query string |
 | `Network error: Failed to get engine URL` | Network connectivity issues   | Check your internet connection and firewall settings                           |
 | `Query error: Line 1, Column 15: relation \"non_existent_table\" does not exist` | Invalid SQL query             | Verify your SQL query has correct syntax and uses valid table and column names |
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -258,6 +258,7 @@ pub struct FireboltClientFactory {
     database_name: Option<String>,
     engine_name: Option<String>,
     account_name: Option<String>,
+    url: Option<String>,
     _api_endpoint: String,
 }
 
@@ -269,6 +270,7 @@ impl FireboltClientFactory {
             database_name: None,
             engine_name: None,
             account_name: None,
+            url: None,
             _api_endpoint: "https://api.firebolt.io".to_string(),
         }
     }
@@ -359,7 +361,73 @@ impl FireboltClientFactory {
         self
     }
 
-    pub async fn build(self) -> Result<FireboltClient, FireboltError> {
+    pub fn with_url(mut self, url: String) -> Self {
+        self.url = Some(url);
+        self
+    }
+
+    pub async fn build(mut self) -> Result<FireboltClient, FireboltError> {
+        match self.url.take() {
+            Some(url) => self.build_core(url).await,
+            None => self.build_cloud().await,
+        }
+    }
+
+    async fn build_core(self, url: String) -> Result<FireboltClient, FireboltError> {
+        Self::validate_core_url(&url)?;
+
+        let mut client = FireboltClient {
+            _auth: None,
+            _parameters: HashMap::new(),
+            _engine_url: url,
+        };
+
+        if let Some(database_name) = self.database_name {
+            let use_database_sql = format!("USE DATABASE \"{database_name}\"");
+            client.query(&use_database_sql).await.map_err(|e| {
+                FireboltError::Configuration(format!("Failed to set database: {e}"))
+            })?;
+        }
+
+        Ok(client)
+    }
+
+    fn validate_core_url(url: &str) -> Result<(), FireboltError> {
+        let parsed = Url::parse(url)
+            .map_err(|e| FireboltError::Configuration(format!("Invalid url '{url}': {e}")))?;
+
+        if parsed.scheme() != "http" && parsed.scheme() != "https" {
+            return Err(FireboltError::Configuration(format!(
+                "Invalid url '{url}': scheme must be http or https"
+            )));
+        }
+
+        let host_missing = match parsed.host_str() {
+            Some(host) => host.is_empty(),
+            None => true,
+        };
+        if host_missing {
+            return Err(FireboltError::Configuration(format!(
+                "Invalid url '{url}': missing host"
+            )));
+        }
+
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return Err(FireboltError::Configuration(format!(
+                "Invalid url '{url}': credentials in the url are not supported, Firebolt Core has no authentication"
+            )));
+        }
+
+        if parsed.query().is_some() || parsed.fragment().is_some() {
+            return Err(FireboltError::Configuration(format!(
+                "Invalid url '{url}': a query string or fragment is not supported"
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn build_cloud(self) -> Result<FireboltClient, FireboltError> {
         // 1. Validate required parameters
         let client_id = self
             .client_id
@@ -469,6 +537,121 @@ mod tests {
         let error = result.unwrap_err();
         assert!(matches!(error, FireboltError::Authentication(_)));
         assert!(format!("{error}").contains("core says no"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_no_credentials_succeeds() {
+        let server = mockito::Server::new_async().await;
+
+        let client = FireboltClient::builder()
+            .with_url(server.url())
+            .build()
+            .await
+            .expect("core build should succeed");
+
+        assert_eq!(client.client_id(), None);
+        assert_eq!(client.client_secret(), None);
+        assert_eq!(client.api_endpoint(), None);
+        assert_eq!(client.engine_url(), server.url());
+    }
+
+    #[tokio::test]
+    async fn test_build_core_with_database_issues_use_database() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_query(Matcher::Any)
+            .match_body("USE DATABASE \"my_db\"")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"meta": [{"name": "test", "type": "int"}], "data": [[1]]}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let result = FireboltClient::builder()
+            .with_url(server.url())
+            .with_database("my_db".to_string())
+            .build()
+            .await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_build_core_query_omits_authorization_header() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_query(Matcher::Any)
+            .match_header("Authorization", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"meta": [{"name": "test", "type": "int"}], "data": [[1]]}"#)
+            .create_async()
+            .await;
+
+        let mut client = FireboltClient::builder()
+            .with_url(server.url())
+            .build()
+            .await
+            .expect("core build should succeed");
+
+        let result = client.query("SELECT 1").await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_url_without_scheme() {
+        let result = FireboltClient::builder()
+            .with_url("localhost:3473".to_string())
+            .build()
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            FireboltError::Configuration(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_url_without_host() {
+        let result = FireboltClient::builder()
+            .with_url("http://".to_string())
+            .build()
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            FireboltError::Configuration(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_url_with_user_info() {
+        let result = FireboltClient::builder()
+            .with_url("http://user:pass@localhost:3473".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("credentials in the url"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_url_with_query_string() {
+        let result = FireboltClient::builder()
+            .with_url("http://localhost:3473/core?tenant=a".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("query string"));
     }
 
     #[test]
@@ -693,6 +876,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: Some("test_account".to_string()),
+            url: None,
             _api_endpoint: api_endpoint,
         };
 
@@ -738,6 +922,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: Some("test_account".to_string()),
+            url: None,
             _api_endpoint: api_endpoint,
         };
 
@@ -783,6 +968,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: None,
+            url: None,
             _api_endpoint: api_endpoint,
         };
 
@@ -807,6 +993,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: Some("test_account".to_string()),
+            url: None,
             _api_endpoint: "https://api.test.firebolt.io".to_string(),
         };
 
@@ -831,6 +1018,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: Some("nonexistent_account".to_string()),
+            url: None,
             _api_endpoint: "https://api.test.firebolt.io".to_string(),
         };
 
@@ -855,6 +1043,7 @@ mod tests {
             database_name: None,
             engine_name: None,
             account_name: Some("test_account".to_string()),
+            url: None,
             _api_endpoint: "https://api.test.firebolt.io".to_string(),
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -374,6 +374,25 @@ impl FireboltClientFactory {
     }
 
     async fn build_core(self, url: String) -> Result<FireboltClient, FireboltError> {
+        if self.client_id.is_some() || self.client_secret.is_some() {
+            return Err(FireboltError::Configuration(
+                "client_id and client_secret cannot be combined with url: Firebolt Core has no authentication".to_string(),
+            ));
+        }
+
+        if self.account_name.is_some() {
+            return Err(FireboltError::Configuration(
+                "account_name cannot be combined with url: Firebolt Core has no accounts"
+                    .to_string(),
+            ));
+        }
+
+        if self.engine_name.is_some() {
+            return Err(FireboltError::Configuration(
+                "engine cannot be combined with url: Firebolt Core has no engines".to_string(),
+            ));
+        }
+
         Self::validate_core_url(&url)?;
 
         let mut client = FireboltClient {
@@ -652,6 +671,51 @@ mod tests {
         let error = result.unwrap_err();
         assert!(matches!(error, FireboltError::Configuration(_)));
         assert!(format!("{error}").contains("query string"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_credentials() {
+        let server = mockito::Server::new_async().await;
+
+        let result = FireboltClient::builder()
+            .with_url(server.url())
+            .with_credentials("id".to_string(), "secret".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("client_id"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_account() {
+        let server = mockito::Server::new_async().await;
+
+        let result = FireboltClient::builder()
+            .with_url(server.url())
+            .with_account("my_account".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("account_name"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_engine() {
+        let server = mockito::Server::new_async().await;
+
+        let result = FireboltClient::builder()
+            .with_url(server.url())
+            .with_engine("my_engine".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("engine"));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,7 +169,12 @@ impl FireboltClient {
             let url = Url::parse(FireboltClientFactory::fix_schema(endpoint_str).as_str())
                 .map_err(|e| FireboltError::HeaderParsing(format!("Invalid endpoint URL: {e}")))?;
 
-            let base_url = format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""));
+            let scheme = url.scheme();
+            let host = url.host_str().unwrap_or("");
+            let base_url = match url.port() {
+                Some(port) => format!("{scheme}://{host}:{port}"),
+                None => format!("{scheme}://{host}"),
+            };
             let path = url.path();
             self._engine_url = if path == "/" || path.is_empty() {
                 base_url
@@ -1177,6 +1182,28 @@ mod tests {
         assert_eq!(result, "http://custom.api.firebolt.io");
 
         std::env::remove_var("FIREBOLT_API_ENDPOINT");
+    }
+
+    #[tokio::test]
+    async fn test_process_response_headers_update_endpoint_keeps_port() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header(HEADER_UPDATE_ENDPOINT, "http://localhost:3473/x")
+            .with_body(r#"{"meta": [{"name": "test", "type": "int"}], "data": [[1]]}"#)
+            .create_async()
+            .await;
+
+        let mut client = create_test_core_client(server.url());
+
+        let result = client.query("SELECT 1").await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
+        assert_eq!(client.engine_url(), "http://localhost:3473/x");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -66,19 +66,21 @@ impl FireboltClient {
         let status = response.status();
 
         if status == 401 {
-            let refresh = if should_retry {
-                self._auth.as_ref().map(|auth| {
-                    (
-                        auth.client_id.clone(),
-                        auth.client_secret.clone(),
-                        auth.api_endpoint.clone(),
-                    )
-                })
-            } else {
-                None
-            };
+            let credentials = self._auth.as_ref().map(|auth| {
+                (
+                    auth.client_id.clone(),
+                    auth.client_secret.clone(),
+                    auth.api_endpoint.clone(),
+                )
+            });
 
-            if let Some((client_id, client_secret, api_endpoint)) = refresh {
+            if let Some((client_id, client_secret, api_endpoint)) = credentials {
+                if !should_retry {
+                    return Err(FireboltError::Authentication(
+                        "Authentication failed after token refresh".to_string(),
+                    ));
+                }
+
                 let (new_token, _expiration) =
                     crate::auth::authenticate(client_id, client_secret, api_endpoint)
                         .await
@@ -373,12 +375,12 @@ impl FireboltClientFactory {
 
     pub async fn build(mut self) -> Result<FireboltClient, FireboltError> {
         match self.url.take() {
-            Some(url) => self.build_core(url).await,
+            Some(url) => self.build_core(&url).await,
             None => self.build_cloud().await,
         }
     }
 
-    async fn build_core(self, url: String) -> Result<FireboltClient, FireboltError> {
+    async fn build_core(self, url: &str) -> Result<FireboltClient, FireboltError> {
         if self.client_id.is_some() || self.client_secret.is_some() {
             return Err(FireboltError::Configuration(
                 "client_id and client_secret cannot be combined with url: Firebolt Core has no authentication".to_string(),
@@ -398,12 +400,10 @@ impl FireboltClientFactory {
             ));
         }
 
-        Self::validate_core_url(&url)?;
-
         let mut client = FireboltClient {
             _auth: None,
             _parameters: HashMap::new(),
-            _engine_url: url,
+            _engine_url: Self::validate_core_url(url)?,
         };
 
         if let Some(database_name) = self.database_name {
@@ -416,14 +416,16 @@ impl FireboltClientFactory {
         Ok(client)
     }
 
-    fn validate_core_url(url: &str) -> Result<(), FireboltError> {
+    // Returns the canonical form: what the caller passed may differ from what url::Url accepted.
+    // Errors never echo the url back, since it may carry a password or a token.
+    fn validate_core_url(url: &str) -> Result<String, FireboltError> {
         let parsed = Url::parse(url)
-            .map_err(|e| FireboltError::Configuration(format!("Invalid url '{url}': {e}")))?;
+            .map_err(|e| FireboltError::Configuration(format!("Invalid url: {e}")))?;
 
         if parsed.scheme() != "http" && parsed.scheme() != "https" {
-            return Err(FireboltError::Configuration(format!(
-                "Invalid url '{url}': scheme must be http or https"
-            )));
+            return Err(FireboltError::Configuration(
+                "Invalid url: scheme must be http or https".to_string(),
+            ));
         }
 
         let host_missing = match parsed.host_str() {
@@ -431,24 +433,31 @@ impl FireboltClientFactory {
             None => true,
         };
         if host_missing {
-            return Err(FireboltError::Configuration(format!(
-                "Invalid url '{url}': missing host"
-            )));
+            return Err(FireboltError::Configuration(
+                "Invalid url: missing host".to_string(),
+            ));
         }
 
         if !parsed.username().is_empty() || parsed.password().is_some() {
-            return Err(FireboltError::Configuration(format!(
-                "Invalid url '{url}': credentials in the url are not supported, Firebolt Core has no authentication"
-            )));
+            return Err(FireboltError::Configuration(
+                "Invalid url: credentials in the url are not supported, Firebolt Core has no authentication".to_string(),
+            ));
+        }
+
+        if parsed.path() != "/" && !parsed.path().is_empty() {
+            return Err(FireboltError::Configuration(
+                "Invalid url: a path is not supported, expected <scheme>://<host>[:<port>]"
+                    .to_string(),
+            ));
         }
 
         if parsed.query().is_some() || parsed.fragment().is_some() {
-            return Err(FireboltError::Configuration(format!(
-                "Invalid url '{url}': a query string or fragment is not supported"
-            )));
+            return Err(FireboltError::Configuration(
+                "Invalid url: a query string or fragment is not supported".to_string(),
+            ));
         }
 
-        Ok(())
+        Ok(parsed.to_string())
     }
 
     async fn build_cloud(self) -> Result<FireboltClient, FireboltError> {
@@ -581,7 +590,33 @@ mod tests {
         assert_eq!(client.client_id(), None);
         assert_eq!(client.client_secret(), None);
         assert_eq!(client.api_endpoint(), None);
-        assert_eq!(client.engine_url(), server.url());
+        assert_eq!(client.engine_url(), format!("{}/", server.url()));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_normalises_the_url() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"meta": [{"name": "test", "type": "int"}], "data": [[1]]}"#)
+            .create_async()
+            .await;
+
+        let mut client = FireboltClient::builder()
+            .with_url(format!("{} ", server.url()))
+            .build()
+            .await
+            .expect("core build should succeed");
+
+        assert_eq!(client.engine_url(), format!("{}/", server.url()));
+
+        let result = client.query("SELECT 1").await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -674,13 +709,50 @@ mod tests {
     #[tokio::test]
     async fn test_build_core_rejects_url_with_query_string() {
         let result = FireboltClient::builder()
-            .with_url("http://localhost:3473/core?tenant=a".to_string())
+            .with_url("http://localhost:3473?tenant=a".to_string())
             .build()
             .await;
 
         let error = result.unwrap_err();
         assert!(matches!(error, FireboltError::Configuration(_)));
         assert!(format!("{error}").contains("query string"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_rejects_url_with_path() {
+        let result = FireboltClient::builder()
+            .with_url("http://localhost:3473/firebolt".to_string())
+            .build()
+            .await;
+
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Configuration(_)));
+        assert!(format!("{error}").contains("path"));
+    }
+
+    #[tokio::test]
+    async fn test_build_core_accepts_root_path() {
+        let server = mockito::Server::new_async().await;
+        let root = format!("{}/", server.url());
+
+        let result = FireboltClient::builder().with_url(root).build().await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_build_core_url_error_does_not_leak_credentials() {
+        let password = "p".repeat(8);
+        let authority = format!("u:{password}@localhost:3473");
+
+        let result = FireboltClient::builder()
+            .with_url(format!("http://{authority}"))
+            .build()
+            .await;
+
+        let error = format!("{}", result.unwrap_err());
+        assert!(error.contains("credentials in the url"));
+        assert!(!error.contains(&password));
     }
 
     #[tokio::test]
@@ -816,10 +888,9 @@ mod tests {
 
         mock.assert_async().await;
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            FireboltError::Authentication(_)
-        ));
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Authentication(_)));
+        assert!(format!("{error}").contains("after token refresh"));
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,13 +9,18 @@ const HEADER_RESET_SESSION: &str = "Firebolt-Reset-Session";
 const HEADER_REMOVE_PARAMETERS: &str = "Firebolt-Remove-Parameters";
 
 #[derive(Debug)]
+struct CloudAuth {
+    client_id: String,
+    client_secret: String,
+    api_endpoint: String,
+    token: String,
+}
+
+#[derive(Debug)]
 pub struct FireboltClient {
-    _client_id: String,
-    _client_secret: String,
-    _token: String,
+    _auth: Option<CloudAuth>,
     _parameters: HashMap<String, String>,
     _engine_url: String,
-    _api_endpoint: String,
 }
 
 impl FireboltClient {
@@ -37,40 +42,66 @@ impl FireboltClient {
         should_retry: bool,
     ) -> Result<ResultSet, FireboltError> {
         let client = reqwest::Client::new();
-        let token = &self._token;
 
-        let response = client
+        let mut request = client
             .post(url)
             .query(params)
-            .header("Authorization", format!("Bearer {token}"))
             .header("User-Agent", crate::version::user_agent())
             .header(
                 "Firebolt-Protocol-Version",
                 crate::version::PROTOCOL_VERSION,
             )
-            .body(sql.to_string())
+            .body(sql.to_string());
+
+        if let Some(auth) = &self._auth {
+            let token = &auth.token;
+            request = request.header("Authorization", format!("Bearer {token}"));
+        }
+
+        let response = request
             .send()
             .await
             .map_err(|e| FireboltError::Network(format!("Request failed: {e}")))?;
 
         let status = response.status();
 
-        if status == 401 && should_retry {
-            let (new_token, _expiration) = crate::auth::authenticate(
-                self.client_id().to_string(),
-                self.client_secret().to_string(),
-                self.api_endpoint().to_string(),
-            )
-            .await
-            .map_err(|e| FireboltError::Authentication(format!("Token refresh failed: {e}")))?;
+        if status == 401 {
+            let refresh = if should_retry {
+                self._auth.as_ref().map(|auth| {
+                    (
+                        auth.client_id.clone(),
+                        auth.client_secret.clone(),
+                        auth.api_endpoint.clone(),
+                    )
+                })
+            } else {
+                None
+            };
 
-            self.set_token(new_token);
-            Box::pin(self.execute_query_request(url, sql, params, false)).await
-        } else if status == 401 {
-            Err(FireboltError::Authentication(
-                "Authentication failed after token refresh".to_string(),
-            ))
-        } else if status.is_server_error() {
+            if let Some((client_id, client_secret, api_endpoint)) = refresh {
+                let (new_token, _expiration) =
+                    crate::auth::authenticate(client_id, client_secret, api_endpoint)
+                        .await
+                        .map_err(|e| {
+                            FireboltError::Authentication(format!("Token refresh failed: {e}"))
+                        })?;
+
+                self.set_token(new_token)?;
+                return Box::pin(self.execute_query_request(url, sql, params, false)).await;
+            }
+
+            let body = response.text().await.map_err(|e| {
+                FireboltError::Network(format!("Failed to read error response: {e}"))
+            })?;
+
+            return Err(FireboltError::Authentication(if body.trim().is_empty() {
+                "Authentication failed".to_string()
+            } else {
+                body
+            }));
+        }
+
+        if status.is_server_error() {
             let body = response.text().await.map_err(|e| {
                 FireboltError::Network(format!("Failed to read error response: {e}"))
             })?;
@@ -90,16 +121,16 @@ impl FireboltClient {
         }
     }
 
-    pub fn client_id(&self) -> &str {
-        &self._client_id
+    pub fn client_id(&self) -> Option<&str> {
+        self._auth.as_ref().map(|auth| auth.client_id.as_str())
     }
 
-    pub fn client_secret(&self) -> &str {
-        &self._client_secret
+    pub fn client_secret(&self) -> Option<&str> {
+        self._auth.as_ref().map(|auth| auth.client_secret.as_str())
     }
 
-    pub fn api_endpoint(&self) -> &str {
-        &self._api_endpoint
+    pub fn api_endpoint(&self) -> Option<&str> {
+        self._auth.as_ref().map(|auth| auth.api_endpoint.as_str())
     }
 
     pub fn engine_url(&self) -> &str {
@@ -110,8 +141,16 @@ impl FireboltClient {
         &self._parameters
     }
 
-    pub fn set_token(&mut self, token: String) {
-        self._token = token;
+    pub fn set_token(&mut self, token: String) -> Result<(), FireboltError> {
+        match self._auth.as_mut() {
+            Some(auth) => {
+                auth.token = token;
+                Ok(())
+            }
+            None => Err(FireboltError::Configuration(
+                "set_token is not applicable to a Firebolt Core connection, which has no authentication".to_string(),
+            )),
+        }
     }
 
     pub fn builder() -> FireboltClientFactory {
@@ -345,12 +384,14 @@ impl FireboltClientFactory {
         let engine_url = Self::get_engine_url(&account_name, &api_endpoint, &token).await?;
 
         let mut client = FireboltClient {
-            _client_id: client_id,
-            _client_secret: client_secret,
-            _token: token,
+            _auth: Some(CloudAuth {
+                client_id,
+                client_secret,
+                api_endpoint,
+                token,
+            }),
             _parameters: HashMap::new(),
             _engine_url: engine_url,
-            _api_endpoint: api_endpoint,
         };
 
         if let Some(database_name) = self.database_name {
@@ -375,6 +416,72 @@ impl FireboltClientFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::Matcher;
+
+    fn create_test_core_client(engine_url: String) -> FireboltClient {
+        FireboltClient {
+            _auth: None,
+            _parameters: HashMap::new(),
+            _engine_url: engine_url,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_query_request_omits_authorization_without_auth() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .match_header("Authorization", Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"meta": [{"name": "test", "type": "int"}], "data": [[1]]}"#)
+            .create_async()
+            .await;
+
+        let mut client = create_test_core_client(server.url());
+
+        let result = client
+            .execute_query_request(&server.url(), "SELECT 1", &HashMap::new(), true)
+            .await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute_query_request_401_without_auth_is_not_retried() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/")
+            .with_status(401)
+            .with_body("core says no")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let mut client = create_test_core_client(server.url());
+
+        let result = client
+            .execute_query_request(&server.url(), "SELECT 1", &HashMap::new(), true)
+            .await;
+
+        mock.assert_async().await;
+        let error = result.unwrap_err();
+        assert!(matches!(error, FireboltError::Authentication(_)));
+        assert!(format!("{error}").contains("core says no"));
+    }
+
+    #[test]
+    fn test_set_token_on_core_client_is_rejected() {
+        let mut client = create_test_core_client("http://localhost:3473".to_string());
+
+        let result = client.set_token("whatever".to_string());
+
+        assert!(matches!(
+            result.unwrap_err(),
+            FireboltError::Configuration(_)
+        ));
+    }
 
     #[tokio::test]
     async fn test_execute_query_request_success() {
@@ -485,9 +592,9 @@ mod tests {
     #[test]
     fn test_client_getters() {
         let client = create_test_client();
-        assert_eq!(client.client_id(), "test_id");
-        assert_eq!(client.client_secret(), "test_secret");
-        assert_eq!(client.api_endpoint(), "https://api.test.firebolt.io");
+        assert_eq!(client.client_id(), Some("test_id"));
+        assert_eq!(client.client_secret(), Some("test_secret"));
+        assert_eq!(client.api_endpoint(), Some("https://api.test.firebolt.io"));
         assert_eq!(client.engine_url(), "https://test.engine.url/");
         assert!(client.parameters().is_empty());
     }
@@ -495,8 +602,10 @@ mod tests {
     #[test]
     fn test_set_token() {
         let mut client = create_test_client();
-        client.set_token("new_token".to_string());
-        assert_eq!(client._token, "new_token".to_string());
+        client
+            .set_token("new_token".to_string())
+            .expect("a cloud client accepts a token");
+        assert_eq!(client._auth.as_ref().unwrap().token, "new_token");
     }
 
     #[tokio::test]
@@ -542,12 +651,14 @@ mod tests {
 
     fn create_test_client() -> FireboltClient {
         FireboltClient {
-            _client_id: "test_id".to_string(),
-            _client_secret: "test_secret".to_string(),
-            _token: "test_token".to_string(),
+            _auth: Some(CloudAuth {
+                client_id: "test_id".to_string(),
+                client_secret: "test_secret".to_string(),
+                api_endpoint: "https://api.test.firebolt.io".to_string(),
+                token: "test_token".to_string(),
+            }),
             _parameters: HashMap::new(),
             _engine_url: "https://test.engine.url/".to_string(),
-            _api_endpoint: "https://api.test.firebolt.io".to_string(),
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -505,6 +505,11 @@ mod tests {
     use super::*;
     use mockito::Matcher;
 
+    fn env_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
+
     fn create_test_core_client(engine_url: String) -> FireboltClient {
         FireboltClient {
             _auth: None,
@@ -911,6 +916,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_missing_client_id() {
+        let _env = env_lock().lock().await;
         let mut server = mockito::Server::new_async().await;
 
         let _auth_mock = server
@@ -957,6 +963,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_missing_client_secret() {
+        let _env = env_lock().lock().await;
         let mut server = mockito::Server::new_async().await;
 
         let _auth_mock = server
@@ -1003,6 +1010,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_missing_account_name() {
+        let _env = env_lock().lock().await;
         let mut server = mockito::Server::new_async().await;
 
         let _auth_mock = server
@@ -1049,6 +1057,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_engine_url_success() {
+        let _env = env_lock().lock().await;
         std::env::set_var("FIREBOLT_API_ENDPOINT", "api.test.firebolt.io");
 
         let factory = FireboltClientFactory {
@@ -1074,6 +1083,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_account_not_found() {
+        let _env = env_lock().lock().await;
         std::env::set_var("FIREBOLT_API_ENDPOINT", "api.test.firebolt.io");
 
         let factory = FireboltClientFactory {
@@ -1099,6 +1109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_server_error() {
+        let _env = env_lock().lock().await;
         std::env::set_var("FIREBOLT_API_ENDPOINT", "api.test.firebolt.io");
 
         let factory = FireboltClientFactory {
@@ -1124,6 +1135,7 @@ mod tests {
 
     #[test]
     fn test_get_api_endpoint_default() {
+        let _env = env_lock().blocking_lock();
         std::env::remove_var("FIREBOLT_API_ENDPOINT");
 
         let result = FireboltClientFactory::get_api_endpoint();
@@ -1133,6 +1145,7 @@ mod tests {
 
     #[test]
     fn test_get_api_endpoint_from_env() {
+        let _env = env_lock().blocking_lock();
         std::env::set_var("FIREBOLT_API_ENDPOINT", "custom.api.firebolt.io");
 
         let result = FireboltClientFactory::get_api_endpoint();
@@ -1144,6 +1157,7 @@ mod tests {
 
     #[test]
     fn test_get_api_endpoint_with_https_prefix() {
+        let _env = env_lock().blocking_lock();
         std::env::set_var("FIREBOLT_API_ENDPOINT", "https://custom.api.firebolt.io");
 
         let result = FireboltClientFactory::get_api_endpoint();
@@ -1155,6 +1169,7 @@ mod tests {
 
     #[test]
     fn test_get_api_endpoint_with_http_prefix() {
+        let _env = env_lock().blocking_lock();
         std::env::set_var("FIREBOLT_API_ENDPOINT", "http://custom.api.firebolt.io");
 
         let result = FireboltClientFactory::get_api_endpoint();

--- a/tests/client_factory_integration.rs
+++ b/tests/client_factory_integration.rs
@@ -29,10 +29,10 @@ async fn test_client_factory_build_integration_happy_path() {
 
     match result {
         Ok(client) => {
-            assert!(!client.client_id().is_empty());
-            assert!(!client.client_secret().is_empty());
+            assert!(client.client_id().is_some_and(|id| !id.is_empty()));
+            assert!(client.client_secret().is_some_and(|s| !s.is_empty()));
             assert!(!client.engine_url().is_empty());
-            assert!(!client.api_endpoint().is_empty());
+            assert!(client.api_endpoint().is_some_and(|e| !e.is_empty()));
         }
         Err(e) => {
             panic!("Integration test failed: {e:?}");
@@ -58,10 +58,10 @@ async fn test_client_factory_build_integration_no_database_no_engine() {
 
     match result {
         Ok(client) => {
-            assert!(!client.client_id().is_empty());
-            assert!(!client.client_secret().is_empty());
+            assert!(client.client_id().is_some_and(|id| !id.is_empty()));
+            assert!(client.client_secret().is_some_and(|s| !s.is_empty()));
             assert!(!client.engine_url().is_empty());
-            assert!(!client.api_endpoint().is_empty());
+            assert!(client.api_endpoint().is_some_and(|e| !e.is_empty()));
         }
         Err(e) => {
             panic!("Integration test failed: {e:?}");

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -86,7 +86,9 @@ async fn test_query_with_invalid_token() {
         .await
         .expect("Failed to build client");
 
-    client.set_token("invalid_token".to_string());
+    client
+        .set_token("invalid_token".to_string())
+        .expect("a cloud client accepts a token");
 
     let result = client.query("SELECT 1 as test_column").await;
 


### PR DESCRIPTION
## Summary

`build()` unconditionally required `client_id`, `client_secret` and `account_name` and then authenticated to Firebolt Cloud, so the Rust SDK could not reach a Firebolt Core server at all. This adds `with_url`, which selects the no-authentication Core connection.

Closes: FB-2858

## Changes

**Core mode is selected by the presence of a url.** `with_url("http://host:3473")` routes `build()` down a path that reads no `FIREBOLT_API_ENDPOINT`, calls no `authenticate`, and performs no engine-URL lookup — the supplied url *is* the engine url. Same routing signal as `firebolt-go-sdk` (`settings.Url != ""`) and `jdbc` (`FireboltProperties.getUrl()`), and it is the input the `oss` generation will arrive on later.

**Cloud-only inputs are rejected, not ignored.** Credentials, `account_name` and `engine_name` alongside a Core url each produce a `FireboltError::Configuration` naming the offending input. Go and JDBC both silently ignore them; that is deliberately not copied, since the issue requires credentials be honoured or clearly rejected. Core has no authentication, so honouring is impossible.

**The gap was wider than `build()`.** Three further places assumed a cloud session:

- `execute_query_request` sent `Authorization: Bearer` unconditionally — a Core client would have sent `Bearer ` with an empty token. The header is now added only when credentials exist, matching Go, which omits it for an empty token.
- The 401 retry path called `auth::authenticate`, whose validator requires `api.<env>.firebolt.io`. A 401 from Core would have surfaced as `Token refresh failed: Invalid API endpoint format`. Core now reports what the server actually said; the cloud refresh-once-then-fail contract is unchanged.
- `FireboltClient` stored credentials as plain `String` with `&str` getters, which have no honest value for Core. It now holds one `Option<CloudAuth>` — the single discriminator both the header decision and the 401 decision consult.

**Url validation** requires `<scheme>://<host>[:<port>]` with an `http`/`https` scheme, and stores the parsed url's canonical form. A path, a `user:password@` authority, and a query string or fragment are each rejected; validation errors never echo the url back, since it may carry a password. The url is deliberately not passed through `fix_schema`, which prepends `https://` to any schemeless string and would silently turn a plain-HTTP Core address into a failing HTTPS request.

**Two pre-existing bugs fixed because Core exposes them.** Both are `fix(...)` commits, reviewable on their own:

- `process_response_headers` rebuilt the engine url with `host_str()`, which excludes the port, so a `Firebolt-Update-Endpoint: http://localhost:3473/x` became `http://localhost/x` and every later query went to port 80. Invisible for cloud, whose engine urls are standard-port HTTPS hostnames; a Core url characteristically carries `:3473`. Go gets this right — `splitEngineEndpoint` uses `parsedUrl.Host + Path`, and Go's `Host` includes the port.
- Ten tests mutated the process-global `FIREBOLT_API_ENDPOINT` concurrently, failing about 1 run in 5. They are now serialised.

### Breaking API changes

Version is `0.1.0`. `client_id()`, `client_secret()` and `api_endpoint()` return `Option<&str>`; `set_token` returns `Result<(), FireboltError>`. Both express the same thing: a Core client has no credentials, and an empty `String` standing in for "there is none" is what produced this bug. `set_token` stays public because `tests/query.rs` calls it.

## Verification

`cargo test --lib` — the check `pr-checks.yml` runs. Every new test is network-free: `mockito::Server::url()` is itself a valid Core url.

```
$ cargo test --lib
test result: ok. 65 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.86s
```

```
$ cargo clippy --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

```
$ cargo fmt --check
(no output)
```

Flake fix, 10 consecutive runs, against 2 failures in 8 runs on base commit `aacb241`:

```
$ for i in $(seq 10); do cargo test --lib 2>&1 | grep 'test result:'; done
test result: ok. 60 passed; 0 failed; ...   (x10)
```

**Not exercised:** no run against a real Firebolt Core container, and no cloud integration run — `integration-tests.yml` needs credentials this branch cannot reach. The Core path is proven only against `mockito`. The first real-container proof arrives with the `smoke` gate.

## Risk and rollout

Low risk to the cloud path: it is byte-for-byte the previous `build()` body, and the restructured 401 block preserves the post-refresh error exactly. No rollout steps, no flags. Rollback is a revert.

The real risk is the breaking getter change, which is a compile error for any consumer rather than a silent behaviour change, at `0.1.0`.

## Reviewer notes

Start at `validate_core_url` and `build_core` in `src/client.rs`; they are the whole feature. The subtle part is the 401 block in `execute_query_request` — it keys on `_auth` being `Some` precisely so a Core client can never reach `auth::authenticate`.

Deliberately out of scope: the `/.well-known/firebolt` probe that distinguishes `oss` from `core` at runtime (FB-2860, FB-2863), any `FIREBOLT_CORE_URL` environment plumbing (FB-2856 supplies the url through its caller stub), and the client-side load balancing the Go Core client offers.

One judgement call worth a second opinion: a **path** in a Core url is rejected. `query()` applies `ensure_trailing_slash`, so `https://host/firebolt` would POST to `/firebolt/` — a different path. Preserving it would mean making `ensure_trailing_slash` mode-aware, which touches the cloud path to support a reverse-proxy deployment nothing here can test. Rejecting is what JDBC does. `ensure_trailing_slash` is left alone for a *server-supplied* update-endpoint path, since that behaviour is pre-existing and identical for cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
